### PR TITLE
Updated runtimes pack directory

### DIFF
--- a/Directory.Build.targets
+++ b/Directory.Build.targets
@@ -5,9 +5,7 @@
 
       <!-- Copy runtime libraries for .Net Core 3 -->
     <Copy SourceFiles="$(BaseOutputPath)build\lib\netcoreapp3.0\$(PackageId).dll"
-          DestinationFolder="$(BaseOutputPath)runtimes\win\lib\netcoreapp3.0"/>
-    <Copy SourceFiles="$(BaseOutputPath)build\lib\netcoreapp3.0\$(PackageId).dll"
-          DestinationFolder="$(BaseOutputPath)runtimes\unix\lib\netcoreapp3.0"/>
+          DestinationFolder="$(BaseOutputPath)runtimes\any\lib\netcoreapp3.0"/>
 
       <!-- Copy *.targets for nuget pack -->
     <Copy SourceFiles="$(SlnDir)\Nuget\FastReport.DataVisualization.targets"

--- a/UsedPackages.version
+++ b/UsedPackages.version
@@ -3,7 +3,7 @@
 <!-- This group sets version used packages in FastReport.Compat and package -->
     <PropertyGroup>
 
-        <FRCompatVersion>2021.1.0</FRCompatVersion>
+        <FRCompatVersion>[2021.1.4,2021.2)</FRCompatVersion>
 
         <SystemDrawingCommonVersion>[4.6.0,)</SystemDrawingCommonVersion>
 		

--- a/UsedPackages.version
+++ b/UsedPackages.version
@@ -3,7 +3,7 @@
 <!-- This group sets version used packages in FastReport.Compat and package -->
     <PropertyGroup>
 
-        <FRCompatVersion>[2021.1.4,2021.2)</FRCompatVersion>
+        <FRCompatVersion>2021.1.5</FRCompatVersion>
 
         <SystemDrawingCommonVersion>[4.6.0,)</SystemDrawingCommonVersion>
 		

--- a/_Build_DataVisualization_Packages.bat
+++ b/_Build_DataVisualization_Packages.bat
@@ -9,5 +9,5 @@ rem that's all
 ECHO NOW TRY TO BUILD FR.DataVisualization
 
 pushd .\build
-   Powershell -ExecutionPolicy ByPass -File ".\build.ps1" --target=DataVisualization --solution-filename=DataViz.sln --config=Release  --vers=2021.1.0
+   Powershell -ExecutionPolicy ByPass -File ".\build.ps1" --target=DataVisualization --solution-filename=DataViz.sln --config=Release  --vers=2021.1.4
 popd


### PR DESCRIPTION
- Removed 'win' and 'unix' directory and add 'any' in 'runtimes' directory
- Updated FastReport.Compat version